### PR TITLE
These types are required by the application code to run

### DIFF
--- a/dist/types/DbOptions.js
+++ b/dist/types/DbOptions.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=DbOptions.js.map

--- a/dist/types/JobDefinition.js
+++ b/dist/types/JobDefinition.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=JobDefinition.js.map

--- a/dist/types/JobParameters.js
+++ b/dist/types/JobParameters.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.datefields = void 0;
+exports.datefields = [
+    'lastRunAt',
+    'lastFinishedAt',
+    'nextRunAt',
+    'failedAt',
+    'lockedAt'
+];
+//# sourceMappingURL=JobParameters.js.map

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,10 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"isolatedModules": false,
-		"declaration": true
+		"declaration": true,
+    "emitDeclarationOnly": false,
+    "preserveSymlinks": true
 	},
 	"exclude": ["node_modules", "**/__tests__"],
-	"include": ["./src"]
+	"include": ["src/**/*"],
 }


### PR DESCRIPTION
It would seem these type files are required to run this agenda fork, so we need to ensure they're a part of `/dist` 

```
internal/modules/cjs/loader.js:892
  throw err;
  ^

Error: Cannot find module './types/JobParameters'
Require stack:
```