### PR TITLE
Bump mongodb driver back down to 4 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "debug": "~4",
     "human-interval": "~2",
     "luxon": "^3",
-    "mongodb": "^6"
+    "mongodb": "^4"
   },
   "devDependencies": {
     "@hokify/eslint-config": "^2.3.8",


### PR DESCRIPTION
It would appear 6 uses a version of bson that uses the elvis operator, and in order for Neolith to run that code, Node would need to be upgraded to at least 16 

Let's try bumping down the driver here as a first pass at addressing this issue 